### PR TITLE
Man gen

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,5 +10,6 @@ readme = "README.md"
 
 [dependencies]
 clap = { git = "https://github.com/kbknapp/clap-rs", branch = "v3-dev" }
+roff = "0.1.0"
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ fn main() {
   let _string = page.to_string();
 }
 ```
+Preview by running:
+```sh
+$ cargo run > /tmp/app.man; man /tmp/app.man
+```
 
 ## Installation
 ```sh

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ fn main() {
     .flag(Some("-d"), Some("--debug"), Some("Activate debug mode"))
     .flag(Some("-v"), Some("--verbose"), Some("Verbose mode"));
     .option(Some("-o"), Some("--output"), "output", None, "Output file");
+
+  let _string = page.to_string();
 }
 ```
 

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -3,21 +3,41 @@ extern crate man;
 use man::Man;
 
 fn main() {
-  let page = Man::new("basic")
-    .description("perform basic operations")
-    .author("Alice Person", Some("alice@person.com".into()))
-    .author("Bob Human", Some("bob@human.com".into()))
+  let msg = Man::new("auth-service")
+    .description("authorize & authenticate members")
     .flag(
       Some("-h".into()),
       Some("--help".into()),
       Some("Prints help information.".into()),
     )
     .flag(
-      Some("-v".into()),
-      Some("--verbose".into()),
+      Some("-V".into()),
+      Some("--version".into()),
       Some("Prints version information.".into()),
-    );
+    )
+    .flag(
+      Some("-v".into()),
+      Some("--verbosity".into()),
+      Some("Pass multiple times to print more information.".into()),
+    )
+    .option(
+      Some("-a".into()),
+      Some("--address".into()),
+      Some("The network address to listen to.".into()),
+      "address".into(),
+      Some("127.0.0.1".into()),
+    )
+    .option(
+      Some("-p".into()),
+      Some("--port".into()),
+      Some("The network port to listen to.".into()),
+      "port".into(),
+      None,
+    )
+    .author("Alice Person", Some("alice@person.com".into()))
+    .author("Bob Human", Some("bob@human.com".into()))
+    .render();
   // .option(Some("-o"), Some("--output"), "output", None, "Output file");
 
-  println!("{}", page.render());
+  println!("{}", msg);
 }

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -3,11 +3,15 @@ extern crate man;
 use man::Man;
 
 fn main() {
-  let mut page = Man::new("basic")
+  let page = Man::new("basic")
     .description("perform basic operations")
     .author(&"Alice Person", Some(String::from("alice@person.com")))
-    .author("Bob Human", Some(String::from("bob@human.com")));
-  // .flag(Some("-d"), Some("--debug"), Some("Activate debug mode"))
+    .author("Bob Human", Some(String::from("bob@human.com")))
+    .flag(
+      Some("-d".into()),
+      Some("--debug".into()),
+      Some("activate debug mode".into()),
+    );
   // .flag(Some("-v"), Some("--verbose"), Some("Verbose mode"));
   // .option(Some("-o"), Some("--output"), "output", None, "Output file");
 

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -5,7 +5,7 @@ use man::Man;
 fn main() {
   let mut page = Man::new("basic");
   page.description("A basic example");
-  // .author("Alice", Some("alice@email.com"))
+  page.author(&"Alice", Some(String::from("alice@email.com")));
   // .author("Bob", Some("bob@email.com"))
   // .flag(Some("-d"), Some("--debug"), Some("Activate debug mode"))
   // .flag(Some("-v"), Some("--verbose"), Some("Verbose mode"));

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -5,19 +5,18 @@ use man::Man;
 fn main() {
   let page = Man::new("basic")
     .description("perform basic operations")
-    .author(&"Alice Person", Some(String::from("alice@person.com")))
-    .author("Bob Human", Some(String::from("bob@human.com")))
+    .author("Alice Person", Some("alice@person.com".into()))
+    .author("Bob Human", Some("bob@human.com".into()))
     .flag(
       Some("-h".into()),
       Some("--help".into()),
-      Some("Print help information.".into()),
+      Some("Prints help information.".into()),
     )
     .flag(
       Some("-v".into()),
       Some("--verbose".into()),
       Some("Prints version information.".into()),
     );
-  // .flag(Some("-v"), Some("--verbose"), Some("Verbose mode"));
   // .option(Some("-o"), Some("--output"), "output", None, "Output file");
 
   println!("{}", page.render());

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -6,6 +6,11 @@ fn main() {
   let msg = Man::new("auth-service")
     .description("authorize & authenticate members")
     .argument("path".into())
+    .environment(
+      "PORT".into(),
+      None,
+      Some("The network port to listen to.".into()),
+    )
     .flag(
       Some("-h".into()),
       Some("--help".into()),

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -5,6 +5,7 @@ use man::Man;
 fn main() {
   let msg = Man::new("auth-service")
     .description("authorize & authenticate members")
+    .argument("path".into())
     .flag(
       Some("-h".into()),
       Some("--help".into()),

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -1,0 +1,15 @@
+extern crate man;
+
+use man::Man;
+
+fn main() {
+  let mut page = Man::new("basic");
+  page.description("A basic example");
+  // .author("Alice", Some("alice@email.com"))
+  // .author("Bob", Some("bob@email.com"))
+  // .flag(Some("-d"), Some("--debug"), Some("Activate debug mode"))
+  // .flag(Some("-v"), Some("--verbose"), Some("Verbose mode"));
+  // .option(Some("-o"), Some("--output"), "output", None, "Output file");
+
+  println!("{}", page.render());
+}

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -3,10 +3,10 @@ extern crate man;
 use man::Man;
 
 fn main() {
-  let mut page = Man::new("basic");
-  page.description("perform basic operations");
-  page.author(&"Alice Person", Some(String::from("alice@person.com")));
-  page.author("Bob Human", Some(String::from("bob@human.com")));
+  let mut page = Man::new("basic")
+    .description("perform basic operations")
+    .author(&"Alice Person", Some(String::from("alice@person.com")))
+    .author("Bob Human", Some(String::from("bob@human.com")));
   // .flag(Some("-d"), Some("--debug"), Some("Activate debug mode"))
   // .flag(Some("-v"), Some("--verbose"), Some("Verbose mode"));
   // .option(Some("-o"), Some("--output"), "output", None, "Output file");

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -6,7 +6,7 @@ fn main() {
   let mut page = Man::new("basic");
   page.description("perform basic operations");
   page.author(&"Alice Person", Some(String::from("alice@person.com")));
-  page.author("Bob", Some(String::from("bob@email.com")));
+  page.author("Bob Human", Some(String::from("bob@human.com")));
   // .flag(Some("-d"), Some("--debug"), Some("Activate debug mode"))
   // .flag(Some("-v"), Some("--verbose"), Some("Verbose mode"));
   // .option(Some("-o"), Some("--output"), "output", None, "Output file");

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -4,9 +4,9 @@ use man::Man;
 
 fn main() {
   let mut page = Man::new("basic");
-  page.description("A basic example");
-  page.author(&"Alice", Some(String::from("alice@email.com")));
-  // .author("Bob", Some("bob@email.com"))
+  page.description("perform basic operations");
+  page.author(&"Alice Person", Some(String::from("alice@person.com")));
+  page.author("Bob", Some(String::from("bob@email.com")));
   // .flag(Some("-d"), Some("--debug"), Some("Activate debug mode"))
   // .flag(Some("-v"), Some("--verbose"), Some("Verbose mode"));
   // .option(Some("-o"), Some("--output"), "output", None, "Output file");

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -8,9 +8,14 @@ fn main() {
     .author(&"Alice Person", Some(String::from("alice@person.com")))
     .author("Bob Human", Some(String::from("bob@human.com")))
     .flag(
-      Some("-d".into()),
-      Some("--debug".into()),
-      Some("activate debug mode".into()),
+      Some("-h".into()),
+      Some("--help".into()),
+      Some("Print help information.".into()),
+    )
+    .flag(
+      Some("-v".into()),
+      Some("--verbose".into()),
+      Some("Prints version information.".into()),
     );
   // .flag(Some("-v"), Some("--verbose"), Some("Verbose mode"));
   // .option(Some("-o"), Some("--output"), "output", None, "Output file");

--- a/examples/main.rs
+++ b/examples/main.rs
@@ -1,7 +1,7 @@
 extern crate clap;
 extern crate man;
 
-use clap::{App, AppSettings, Arg, SubCommand};
+use clap::{App, AppSettings, Arg, Man, SubCommand};
 use man::Manual;
 
 fn main() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,8 +4,12 @@
 #![cfg_attr(test, deny(warnings))]
 
 extern crate clap;
+extern crate roff;
+
+mod man;
 
 use clap::{App, Arg, ArgSettings};
+pub use man::*;
 
 /// Describe an argument or option
 #[derive(Debug)]

--- a/src/man/author.rs
+++ b/src/man/author.rs
@@ -1,5 +1,5 @@
 /// An author entry.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Author {
   pub(crate) name: String,
   pub(crate) email: Option<String>,

--- a/src/man/author.rs
+++ b/src/man/author.rs
@@ -1,0 +1,6 @@
+/// An author entry.
+#[derive(Debug)]
+pub struct Author {
+  pub(crate) name: String,
+  pub(crate) email: Option<String>,
+}

--- a/src/man/environment.rs
+++ b/src/man/environment.rs
@@ -1,5 +1,5 @@
 /// Command line environment variable representation.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Env {
   pub(crate) name: String,
   pub(crate) default: Option<String>,

--- a/src/man/environment.rs
+++ b/src/man/environment.rs
@@ -1,0 +1,7 @@
+/// Command line environment variable representation.
+#[derive(Debug)]
+pub struct Env {
+  pub(crate) name: String,
+  pub(crate) default: Option<String>,
+  pub(crate) description: Option<String>,
+}

--- a/src/man/flag.rs
+++ b/src/man/flag.rs
@@ -1,3 +1,7 @@
 /// Command line flag representation.
 #[derive(Debug)]
-pub struct Flag {}
+pub struct Flag {
+  pub(crate) short: Option<String>,
+  pub(crate) long: Option<String>,
+  pub(crate) description: Option<String>,
+}

--- a/src/man/flag.rs
+++ b/src/man/flag.rs
@@ -1,0 +1,3 @@
+/// Command line flag representation.
+#[derive(Debug)]
+pub struct Flag {}

--- a/src/man/flag.rs
+++ b/src/man/flag.rs
@@ -1,5 +1,5 @@
 /// Command line flag representation.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Flag {
   pub(crate) short: Option<String>,
   pub(crate) long: Option<String>,

--- a/src/man/mod.rs
+++ b/src/man/mod.rs
@@ -86,8 +86,8 @@ pub fn description(page: Roff, name: &str, desc: &Option<String>) -> Roff {
 /// ## Formatting
 /// ```txt
 /// AUTHORS
-///           alice person <alice@person.com>
-///           bob human <bob@human.com>
+///          Alice Person <alice@person.com>
+///          Bob Human <bob@human.com>
 /// ```
 #[inline]
 pub fn authors(page: Roff, authors: &[Author]) -> Roff {

--- a/src/man/mod.rs
+++ b/src/man/mod.rs
@@ -31,30 +31,38 @@ impl Man {
   }
 
   /// Add a description.
-  pub fn description(&mut self, desc: &str) {
+  pub fn description(mut self, desc: &str) -> Self {
     let desc = desc.into();
     self.description = Some(desc);
+    self
   }
 
   /// Add an author.
-  pub fn author(&mut self, name: impl AsRef<str>, email: Option<String>) {
+  pub fn author(
+    mut self,
+    name: impl AsRef<str>,
+    email: Option<String>,
+  ) -> Self {
     self.authors.push(Author {
       name: name.as_ref().to_owned(),
       email,
     });
+    self
   }
 
   /// Add an flag.
-  pub fn flag(&mut self, flag: Flag) {
+  pub fn flag(mut self, flag: Flag) -> Self {
     self.flags.push(flag);
+    self
   }
 
   /// Add an option.
-  pub fn option(&mut self, option: Opt) {
+  pub fn option(mut self, option: Opt) -> Self {
     self.options.push(option);
+    self
   }
 
-  pub fn render(&mut self) -> String {
+  pub fn render(self) -> String {
     let man_num = 1;
     let mut page = Roff::new(&self.name, man_num);
 

--- a/src/man/mod.rs
+++ b/src/man/mod.rs
@@ -37,7 +37,7 @@ impl Man {
   }
 
   /// Add an author.
-  pub fn author(&mut self, name: impl AsRef<String>, email: Option<String>) {
+  pub fn author(&mut self, name: impl AsRef<str>, email: Option<String>) {
     self.authors.push(Author {
       name: name.as_ref().to_owned(),
       email,
@@ -59,6 +59,7 @@ impl Man {
     let mut page = Roff::new(&self.name, man_num);
 
     page = description(page, &self.description);
+    page = authors(page, &self.authors);
     page.render()
   }
 }
@@ -94,13 +95,13 @@ pub fn authors(page: Roff, authors: &[Author]) -> Roff {
     _ => "AUTHORS",
   };
 
-  let auth_values = vec![];
+  let mut auth_values = vec![];
   for author in authors.iter() {
-    let email = match author.email {
-      Some(email) => format!("- {:?}", email),
-      None => "".into(),
+    auth_values.push(roff::bold(&author.name));
+
+    if let Some(ref email) = author.email {
+      auth_values.push(format!("- {:?}", email))
     };
-    auth_values.push([roff::bold(&author.name), email]);
   }
 
   page.section(title, &auth_values)

--- a/src/man/mod.rs
+++ b/src/man/mod.rs
@@ -1,0 +1,107 @@
+mod author;
+mod flag;
+mod option;
+
+use self::author::Author;
+use self::flag::Flag;
+use self::option::Opt;
+use roff::{self, Roff, Troffable};
+use std::convert::AsRef;
+
+/// Man page struct.
+#[derive(Debug)]
+pub struct Man {
+  name: String,
+  description: Option<String>,
+  authors: Vec<Author>,
+  flags: Vec<Flag>,
+  options: Vec<Opt>,
+}
+
+impl Man {
+  /// Create a new instance.
+  pub fn new(name: &str) -> Self {
+    Self {
+      name: name.into(),
+      description: None,
+      authors: vec![],
+      flags: vec![],
+      options: vec![],
+    }
+  }
+
+  /// Add a description.
+  pub fn description(&mut self, desc: &str) {
+    let desc = desc.into();
+    self.description = Some(desc);
+  }
+
+  /// Add an author.
+  pub fn author(&mut self, name: impl AsRef<String>, email: Option<String>) {
+    self.authors.push(Author {
+      name: name.as_ref().to_owned(),
+      email,
+    });
+  }
+
+  /// Add an flag.
+  pub fn flag(&mut self, flag: Flag) {
+    self.flags.push(flag);
+  }
+
+  /// Add an option.
+  pub fn option(&mut self, option: Opt) {
+    self.options.push(option);
+  }
+
+  pub fn render(&mut self) -> String {
+    let man_num = 1;
+    let mut page = Roff::new(&self.name, man_num);
+
+    page = description(page, &self.description);
+    page.render()
+  }
+}
+
+/// Create a `NAME` section.
+///
+/// ## Formatting
+/// ```txt
+/// NAME
+///         mycmd - brief description of the application
+/// ```
+pub fn description(page: Roff, desc: &Option<String>) -> Roff {
+  let desc = match desc {
+    Some(ref desc) => format!("- {:?}", desc),
+    None => String::from(""),
+  };
+
+  page.section("NAME", &[desc])
+}
+
+/// Create a `AUTHOR` or `AUTHORS` section.
+///
+/// ## Formatting
+/// ```txt
+/// AUTHORS
+///           alice person <alice@person.com>
+///           bob human <bob@human.com>
+/// ```
+pub fn authors(page: Roff, authors: &[Author]) -> Roff {
+  let title = match authors.len() {
+    0 => return page,
+    1 => "AUTHOR",
+    _ => "AUTHORS",
+  };
+
+  let auth_values = vec![];
+  for author in authors.iter() {
+    let email = match author.email {
+      Some(email) => format!("- {:?}", email),
+      None => "".into(),
+    };
+    auth_values.push([roff::bold(&author.name), email]);
+  }
+
+  page.section(title, &auth_values)
+}

--- a/src/man/mod.rs
+++ b/src/man/mod.rs
@@ -5,7 +5,7 @@ mod option;
 use self::author::Author;
 use self::flag::Flag;
 use self::option::Opt;
-use roff::{Roff, Troffable};
+use roff::{bold, list, Roff, Troffable};
 use std::convert::AsRef;
 
 /// Man page struct.
@@ -51,8 +51,17 @@ impl Man {
   }
 
   /// Add an flag.
-  pub fn flag(mut self, flag: Flag) -> Self {
-    self.flags.push(flag);
+  pub fn flag(
+    mut self,
+    short: Option<String>,
+    long: Option<String>,
+    description: Option<String>,
+  ) -> Self {
+    self.flags.push(Flag {
+      short,
+      long,
+      description,
+    });
     self
   }
 
@@ -65,8 +74,8 @@ impl Man {
   pub fn render(self) -> String {
     let man_num = 1;
     let mut page = Roff::new(&self.name, man_num);
-
     page = description(page, &self.name, &self.description);
+    page = exit_status(page);
     page = authors(page, &self.authors);
     page.render()
   }
@@ -121,6 +130,41 @@ pub fn authors(page: Roff, authors: &[Author]) -> Roff {
   }
 
   page.section(title, &auth_values)
+}
+
+/// Create a `FLAGS` section.
+///
+/// ## Formatting
+/// ```txt
+/// FLAGS
+///          Alice Person <alice@person.com>
+///          Bob Human <bob@human.com>
+/// ```
+pub fn flags(_page: Roff) -> Roff {
+  unimplemented!();
+}
+
+/// Create a `EXIT STATUS` section.
+///
+/// ## Implementation Note
+/// This currently only returns the status code `0`, and takes no arguments. We
+/// should let it take arguments.
+///
+/// ## Formatting
+/// ```txt
+/// EXIT STATUS
+///        0      Successful program execution
+///
+///        1      Usage, syntax or configuration file error
+///
+///        2      Optional error
+/// ```
+pub fn exit_status(page: Roff) -> Roff {
+  let section = "EXIT STATUS";
+  page.section(
+    section,
+    &[list(&[bold("0")], &["Successful program execution."])],
+  )
 }
 
 // NOTE(yw): This code was taken from the npm-install(1) command. The location

--- a/src/man/mod.rs
+++ b/src/man/mod.rs
@@ -11,7 +11,7 @@ use roff::{bold, italic, list, Roff, Troffable};
 use std::convert::AsRef;
 
 /// Man page struct.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Man {
   name: String,
   description: Option<String>,
@@ -140,8 +140,7 @@ impl Man {
 /// NAME
 ///         mycmd - brief description of the application
 /// ```
-#[inline]
-pub fn description(page: Roff, name: &str, desc: &Option<String>) -> Roff {
+fn description(page: Roff, name: &str, desc: &Option<String>) -> Roff {
   let desc = match desc {
     Some(ref desc) => format!("{} - {}", name, desc),
     None => name.to_owned(),
@@ -151,7 +150,7 @@ pub fn description(page: Roff, name: &str, desc: &Option<String>) -> Roff {
 }
 
 /// Create a `SYNOPSIS` section.
-pub fn synopsis(
+fn synopsis(
   page: Roff,
   name: &str,
   flags: &[Flag],
@@ -187,8 +186,7 @@ pub fn synopsis(
 ///          Alice Person <alice@person.com>
 ///          Bob Human <bob@human.com>
 /// ```
-#[inline]
-pub fn authors(page: Roff, authors: &[Author]) -> Roff {
+fn authors(page: Roff, authors: &[Author]) -> Roff {
   let title = match authors.len() {
     0 => return page,
     1 => "AUTHOR",
@@ -219,7 +217,7 @@ pub fn authors(page: Roff, authors: &[Author]) -> Roff {
 /// ```txt
 /// FLAGS
 /// ```
-pub fn flags(page: Roff, flags: &[Flag]) -> Roff {
+fn flags(page: Roff, flags: &[Flag]) -> Roff {
   if flags.is_empty() {
     return page;
   }
@@ -256,7 +254,7 @@ pub fn flags(page: Roff, flags: &[Flag]) -> Roff {
 /// ```txt
 /// OPTIONS
 /// ```
-pub fn options(page: Roff, options: &[Opt]) -> Roff {
+fn options(page: Roff, options: &[Opt]) -> Roff {
   if options.is_empty() {
     return page;
   }
@@ -305,7 +303,7 @@ pub fn options(page: Roff, options: &[Opt]) -> Roff {
 /// ```txt
 /// ENVIRONMENT
 /// ```
-pub fn environment(page: Roff, environment: &[Env]) -> Roff {
+fn environment(page: Roff, environment: &[Env]) -> Roff {
   if environment.is_empty() {
     return page;
   }
@@ -353,7 +351,7 @@ pub fn environment(page: Roff, environment: &[Env]) -> Roff {
 ///
 ///        2      Optional error
 /// ```
-pub fn exit_status(page: Roff) -> Roff {
+fn exit_status(page: Roff) -> Roff {
   page.section(
     "EXIT STATUS",
     &[list(&[bold("0")], &["Successful program execution."])],
@@ -367,7 +365,6 @@ pub fn exit_status(page: Roff) -> Roff {
 // ```sh
 // $ less /usr/share/man/man1/npm-install.1
 // ```
-#[inline]
 fn init_list() -> String {
   format!(".P\n.RS 2\n.nf\n")
 }

--- a/src/man/option.rs
+++ b/src/man/option.rs
@@ -1,5 +1,5 @@
 /// Option
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Opt {
   pub(crate) short: Option<String>,
   pub(crate) long: Option<String>,

--- a/src/man/option.rs
+++ b/src/man/option.rs
@@ -1,0 +1,3 @@
+/// Option
+#[derive(Debug)]
+pub struct Opt {}

--- a/src/man/option.rs
+++ b/src/man/option.rs
@@ -1,3 +1,9 @@
 /// Option
 #[derive(Debug)]
-pub struct Opt {}
+pub struct Opt {
+  pub(crate) short: Option<String>,
+  pub(crate) long: Option<String>,
+  pub(crate) description: Option<String>,
+  pub(crate) argument: String,
+  pub(crate) default: Option<String>,
+}


### PR DESCRIPTION
Adds the man page generation code. Includes an example. Works towards: https://github.com/rust-lang-nursery/cli-wg/issues/42.

Review-wise, this PR is pretty early. I would like to ask to discuss any API design issues in https://github.com/rust-clique/man/issues/2, and focus the review on implementation issues only.

Once we land this the next step would be to wire it up to `structopt` to hit the milestone's goal. Thanks!

## Example Output
![2018-07-19-141825_1920x1080](https://user-images.githubusercontent.com/2467194/42942655-e65c2116-8b60-11e8-8f72-090ab17725fb.png)