### PR TITLE
Readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,9 +78,11 @@ AUTHORS
 ```
 
 ## Installation
+If using [cargo-edit](https://github.com/killercup/cargo-edit), install with
 ```sh
 $ cargo add man
 ```
+Otherwise, install by adding to Cargo.toml file's dependency section.
 
 ## License
 [MIT](./LICENSE-MIT) OR [Apache-2.0](./LICENSE-APACHE)

--- a/README.md
+++ b/README.md
@@ -10,20 +10,34 @@ Generate structured man pages using
 
 ## Usage
 ```rust
-extern crate man;
-
 use man::prelude::*;
 
 fn main() {
-  let page = Manual::new("basic")
-    .about("A basic example")
-    .author(Author::new("Alice Person").email("alice@person.com"))
-    .author(Author::new("Bob Human").email("bob@human.com"))
-    .flag(Flag::new().short("-d").long("--debug").description("Enable debug mode"))
-    .flag(Flag::new().short("-v").long("--verbose").description("Enable verbose mode"))
-    .option(Opt::new("output").short("-o").long("--output").description("The file path to write output to"));
+    let page = Manual::new("basic")
+        .about("A basic example")
+        .author(Author::new("Alice Person").email("alice@person.com"))
+        .author(Author::new("Bob Human").email("bob@human.com"))
+        .flag(
+            Flag::new()
+                .short("-d")
+                .long("--debug")
+                .help("Enable debug mode"),
+        )
+        .flag(
+            Flag::new()
+                .short("-v")
+                .long("--verbose")
+                .help("Enable verbose mode"),
+        )
+        .option(
+            Opt::new("output")
+                .short("-o")
+                .long("--output")
+                .help("The file path to write output to"),
+        )
+        .render();
 
-  let _string = page.render();
+    println!("{}", page);
 }
 ```
 Preview by running:

--- a/examples/main.rs
+++ b/examples/main.rs
@@ -12,22 +12,26 @@ fn main() {
         .short("-h")
         .long("--help")
         .help("Prints help information."),
-    ).flag(
+    )
+    .flag(
       Flag::new()
         .short("-V")
         .long("--version")
         .help("Prints version information."),
-    ).flag(
+    )
+    .flag(
       Flag::new()
         .short("-v")
         .long("--verbosity")
         .help("Pass multiple times to print more information."),
-    ).option(
+    )
+    .option(
       Opt::new("port")
         .short("-p")
         .long("--port")
         .help("The network port to listen to."),
-    ).author(Author::new("Alice Person").email("alice@person.com"))
+    )
+    .author(Author::new("Alice Person").email("alice@person.com"))
     .author(Author::new("Bob Human").email("bob@human.com"))
     .render();
   // .option(Some("-o"), Some("--output"), "output", None, "Output file");


### PR DESCRIPTION

This PR fixes the usage example (a fix for #21)

The usage example did not previously compile because it used `.description`, which didn't exist.  The commit fixes the code to use `.help`, which does exists.

The PR also prints the output rather than saving it to an unused variable, which allows the `preview` instructions below the usage example to function as the README describes.

Finally (and in a separate commit, since it is slightly unrelated), the PR clarifies the README's installation instructions.  The installation instructions assume that the user has `cargo-edit` installed (which is a great crate, by the way!).  However, `cargo-edit` isn't built in, so I added instructions for including `man` in the `Cargo.toml` file directly.  
