### PR TITLE
Add custom section

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ fn main() {
                 .help("The file path to write output to"),
         )
         .custom(
-            Sec::new("usage note")
+            Section::new("usage note")
                 .paragraph("This program will overwrite any file currently stored at the output path")
         )
         .render();

--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ fn main() {
                 .long("--output")
                 .help("The file path to write output to"),
         )
+        .custom(
+            Sec::new("usage note")
+                .paragraph("This program will overwrite any file currently stored at the output path")
+        )
         .render();
 
     println!("{}", page);
@@ -56,15 +60,17 @@ SYNOPSIS
 
 FLAGS
        -d, --debug
-              Enable debug mode.
+              Enable debug mode
 
        -v, --verbose
               Enable verbose mode
 
 OPTIONS
        -o, --output=output
-              The file path to write output to.
+              The file path to write output to
 
+USAGE NOTE
+       This file will overwrite any file currently stored at the output path.
 EXIT STATUS
        0      Successful program execution.
 

--- a/examples/main.rs
+++ b/examples/main.rs
@@ -31,6 +31,11 @@ fn main() {
         .long("--port")
         .help("The network port to listen to."),
     )
+    .custom(
+      Sec::new("custom section")
+        .paragraph("text for the custom section")
+        .paragraph("Additional text for the custom section"),
+    )
     .author(Author::new("Alice Person").email("alice@person.com"))
     .author(Author::new("Bob Human").email("bob@human.com"))
     .render();

--- a/examples/main.rs
+++ b/examples/main.rs
@@ -32,7 +32,7 @@ fn main() {
         .help("The network port to listen to."),
     )
     .custom(
-      Sec::new("custom section")
+      Section::new("custom section")
         .paragraph("text for the custom section")
         .paragraph("Additional text for the custom section"),
     )

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,4 +21,4 @@ pub use environment::Env;
 pub use flag::Flag;
 pub use man::Manual;
 pub use option::Opt;
-pub use section::Sec;
+pub use section::Section;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ mod environment;
 mod flag;
 mod man;
 mod option;
+mod section;
 
 pub mod prelude;
 
@@ -20,3 +21,4 @@ pub use environment::Env;
 pub use flag::Flag;
 pub use man::Manual;
 pub use option::Opt;
+pub use section::Sec;

--- a/src/man.rs
+++ b/src/man.rs
@@ -12,6 +12,7 @@ pub struct Manual {
   options: Vec<Opt>,
   environment: Vec<Env>,
   arguments: Vec<Arg>,
+  custom_sections: Vec<Sec>,
 }
 
 impl Manual {
@@ -26,6 +27,7 @@ impl Manual {
       options: vec![],
       arguments: vec![],
       environment: vec![],
+      custom_sections: vec![],
     }
   }
 
@@ -65,6 +67,12 @@ impl Manual {
     self
   }
 
+  /// Add a custom section
+  pub fn custom(mut self, custom_section: Sec) -> Self {
+    self.custom_sections.push(custom_section);
+    self
+  }
+
   /// Add a positional argument. The items are displayed in the order they're
   /// pushed.
   // TODO: make this accept argument vecs / optional args too.  `arg...`, `arg?`
@@ -89,6 +97,9 @@ impl Manual {
     page = flags(page, &self.flags);
     page = options(page, &self.options);
     page = env(page, &self.environment);
+    for section in self.custom_sections.into_iter() {
+      page = custom(page, section);
+    }
     page = exit_status(page);
     page = authors(page, &self.authors);
     page.render()
@@ -338,6 +349,15 @@ fn exit_status(page: Roff) -> Roff {
       list(&[bold("101")], &["The program panicked."]),
     ],
   )
+}
+
+fn custom(page: Roff, custom_section: Sec) -> Roff {
+  let mut paragraphs: Vec<String> = vec![];
+  for paragraph in custom_section.paragraphs.into_iter() {
+    paragraphs.push(paragraph);
+    paragraphs.push("\n\n".into())
+  }
+  page.section(&custom_section.name, &paragraphs)
 }
 
 // NOTE(yw): This code was taken from the npm-install(1) command. The location

--- a/src/man.rs
+++ b/src/man.rs
@@ -351,6 +351,20 @@ fn exit_status(page: Roff) -> Roff {
   )
 }
 
+/// Create a custom section.
+///
+/// The custom section will have the title you specify as the argument to the
+/// .new() method and may optionally be followed by one or more paragraphs
+/// using the .paragraph() method.
+///
+/// ## Formatting
+/// ```txt
+/// SECTION NAME
+///        Text of first paragraph
+///
+///        Text of second paragraph
+///
+/// ```
 fn custom(page: Roff, custom_section: Sec) -> Roff {
   let mut paragraphs: Vec<String> = vec![];
   for paragraph in custom_section.paragraphs.into_iter() {

--- a/src/man.rs
+++ b/src/man.rs
@@ -12,7 +12,7 @@ pub struct Manual {
   options: Vec<Opt>,
   environment: Vec<Env>,
   arguments: Vec<Arg>,
-  custom_sections: Vec<Sec>,
+  custom_sections: Vec<Section>,
 }
 
 impl Manual {
@@ -68,7 +68,7 @@ impl Manual {
   }
 
   /// Add a custom section
-  pub fn custom(mut self, custom_section: Sec) -> Self {
+  pub fn custom(mut self, custom_section: Section) -> Self {
     self.custom_sections.push(custom_section);
     self
   }
@@ -365,7 +365,7 @@ fn exit_status(page: Roff) -> Roff {
 ///        Text of second paragraph
 ///
 /// ```
-fn custom(page: Roff, custom_section: Sec) -> Roff {
+fn custom(page: Roff, custom_section: Section) -> Roff {
   let mut paragraphs: Vec<String> = vec![];
   for paragraph in custom_section.paragraphs.into_iter() {
     paragraphs.push(paragraph);

--- a/src/mod.rs
+++ b/src/mod.rs
@@ -1,9 +1,11 @@
 mod author;
+mod custom;
 mod environment;
 mod flag;
 mod option;
 
 use self::author::Author;
+use self::custom::Para;
 use self::environment::Env;
 use self::flag::Flag;
 use self::option::Opt;
@@ -20,6 +22,7 @@ pub struct Man {
   options: Vec<Opt>,
   environment: Vec<Env>,
   arguments: Vec<String>,
+  custom: Vec<Para>,
 }
 
 impl Man {
@@ -78,11 +81,7 @@ impl Man {
     long: Option<String>,
     help: Option<String>,
   ) -> Self {
-    self.flags.push(Flag {
-      short,
-      long,
-      help,
-    });
+    self.flags.push(Flag { short, long, help });
     self
   }
 

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -15,4 +15,4 @@ pub use environment::Env;
 pub use flag::Flag;
 pub use man::Manual;
 pub use option::Opt;
-pub use section::Sec;
+pub use section::Section;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -15,3 +15,4 @@ pub use environment::Env;
 pub use flag::Flag;
 pub use man::Manual;
 pub use option::Opt;
+pub use section::Sec;

--- a/src/section.rs
+++ b/src/section.rs
@@ -1,11 +1,11 @@
-/// Positional arguments.
+/// Add a custom section
 #[derive(Debug, Clone)]
-pub struct Sec {
+pub struct Section {
   pub(crate) name: String,
   pub(crate) paragraphs: Vec<String>,
 }
 
-impl Sec {
+impl Section {
   pub fn new(name: &str) -> Self {
     Self {
       name: name.into(),

--- a/src/section.rs
+++ b/src/section.rs
@@ -1,0 +1,20 @@
+/// Positional arguments.
+#[derive(Debug, Clone)]
+pub struct Sec {
+  pub(crate) name: String,
+  pub(crate) paragraphs: Vec<String>,
+}
+
+impl Sec {
+  pub fn new(name: &str) -> Self {
+    Self {
+      name: name.into(),
+      paragraphs: vec![],
+    }
+  }
+
+  pub fn paragraph(mut self, text: &str) -> Self {
+    self.paragraphs.push(text.into());
+    self
+  }
+}


### PR DESCRIPTION
This PR adds a `.custom` method to the public API, which takes a section title and 0 or more paragraphs of plain text.  Using this method, the following code
```rust
.custom(
    Sec::new("regex syntax")
        .paragraph("ripgrep uses Rust’s regex engine by default, which documents its syntax: https://docs.rs/regex/*/regex/#syntax")
)
```
could generate the first portion of `ripgrep`'s REGEX SYNTAX section.

This PR also adds documentation for the new method to the README, example file, and as a doc comment.

This PR would close #22 